### PR TITLE
予約確定機能

### DIFF
--- a/controller/event.go
+++ b/controller/event.go
@@ -121,12 +121,6 @@ func (ec *eventController) CreateAnswer(c echo.Context) error {
 		return err
 	}
 
-	// すべての回答が集まったら，確定メールを送る
-	if event.UserAnswersCount == event.NumberOfParticipants {
-		if err := util.SendMail(event.ID, event.ConfirmationEmail); err != nil {
-			return apperror.NewUnknownError(fmt.Errorf("failed to send confirmation email: %w", err), nil)
-		}
-	}
 	eventRes := eventToEventResponse(event, user)
 	i := slices.IndexFunc(eventRes.UserAnswers, func(answer entity.UserEventAnswerResponse) bool {
 		return answer.IsYourAnswer

--- a/controller/event.go
+++ b/controller/event.go
@@ -120,6 +120,13 @@ func (ec *eventController) CreateAnswer(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// すべての回答が集まったら，確定メールを送る
+	if event.UserAnswersCount == event.NumberOfParticipants {
+		if err := util.SendMail(event.ID, event.ConfirmationEmail); err != nil {
+			return apperror.NewUnknownError(fmt.Errorf("failed to send confirmation email: %w", err), nil)
+		}
+	}
 	eventRes := eventToEventResponse(event, user)
 	i := slices.IndexFunc(eventRes.UserAnswers, func(answer entity.UserEventAnswerResponse) bool {
 		return answer.IsYourAnswer

--- a/entity/event.go
+++ b/entity/event.go
@@ -15,7 +15,6 @@ type Event struct {
 	UnitSeconds          int               `json:"unitSeconds"`
 	Units                []EventTimeUnit   `json:"units"`
 	UserAnswers          []UserEventAnswer `json:"userAnswers"`
-	UserAnswersCount     int               `json:"userAnswersCount"`
 	NotifyByEmail        bool              `json:"notifyByEmail"`
 	NumberOfParticipants int               `json:"numberOfParticipants"`
 	ConfirmationEmail    string            `json:"confirmationEmail"`

--- a/entity/event.go
+++ b/entity/event.go
@@ -7,22 +7,31 @@ import (
 )
 
 type Event struct {
-	ID            ulid.ULID         `json:"id"`
-	OwnerID       ulid.ULID         `json:"ownerId"`
-	Name          string            `json:"name"`
-	Description   string            `json:"description"`
-	DurationAbout string            `json:"durationAbout"`
-	UnitSeconds   int               `json:"unitSeconds"`
-	Units         []EventTimeUnit   `json:"units"`
-	UserAnswers   []UserEventAnswer `json:"userAnswers"`
+	ID                   ulid.ULID         `json:"id"`
+	OwnerID              ulid.ULID         `json:"ownerId"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description"`
+	DurationAbout        string            `json:"durationAbout"`
+	UnitSeconds          int               `json:"unitSeconds"`
+	Units                []EventTimeUnit   `json:"units"`
+	UserAnswers          []UserEventAnswer `json:"userAnswers"`
+	UserAnswersCount     int               `json:"userAnswersCount"`
+	NotifyByEmail        bool              `json:"notifyByEmail"`
+	NumberOfParticipants int               `json:"numberOfParticipants"`
+	ConfirmationEmail    string            `json:"confirmationEmail"`
 }
+
 type EventRequest struct {
-	Name          string                 `json:"name"`
-	Description   string                 `json:"description"`
-	DurationAbout string                 `json:"durationAbout"`
-	UnitSeconds   int                    `json:"unitDuration"`
-	Units         []EventTimeUnitRequest `json:"units"`
+	Name                 string                 `json:"name"`
+	Description          string                 `json:"description"`
+	DurationAbout        string                 `json:"durationAbout"`
+	UnitSeconds          int                    `json:"unitDuration"`
+	Units                []EventTimeUnitRequest `json:"units"`
+	NotifyByEmail        bool                   `json:"notifyByEmail"`
+	NumberOfParticipants int                    `json:"numberOfParticipants"`
+	ConfirmationEmail    string                 `json:"confirmationEmail"`
 }
+
 type EventResponse struct {
 	ID            string                    `json:"id"`
 	OwnerID       string                    `json:"ownerId"`

--- a/repository/event.go
+++ b/repository/event.go
@@ -30,7 +30,8 @@ type EventRepository interface {
 	FetchEventAnswersWithUnits(ctx context.Context, tx *sql.Tx, eventId ulid.ULID) ([]entity.UserEventAnswer, error)
 	// イベントの指定ユーザー回答(Unit無し)を取得する
 	FetchEventAnswer(ctx context.Context, tx *sql.Tx, eventId ulid.ULID, userId ulid.ULID) (entity.UserEventAnswer, error)
-
+	// 回答したユーザーの数を取得する
+	FetchUserAnswerCount(ctx context.Context, tx *sql.Tx, eventId ulid.ULID) (int, error)
 	// イベント参加回答更新
 	UpdateEventAnswer(ctx context.Context, tx *sql.Tx, answer entity.UserEventAnswer) (entity.UserEventAnswer, error)
 	// イベント参加回答時間単位を登録する
@@ -257,6 +258,22 @@ func (er *eventRepository) FetchEventAnswer(ctx context.Context, tx *sql.Tx, eve
 		Units:        units,
 		// Units:        []entity.UserEventAnswerUnit{},
 	}, nil
+}
+
+// FetchUserAnswerCount implements EventRepository.
+func (er *eventRepository) FetchUserAnswerCount(ctx context.Context, tx *sql.Tx, eventId ulid.ULID) (int, error) {
+	var exc boil.ContextExecutor = tx
+	if tx == nil {
+		exc = er.db
+	}
+
+	count, err := models.UserEventAnswers(
+		models.UserEventAnswerWhere.EventID.EQ(util.ULIDToString(eventId)),
+	).Count(ctx, exc)
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
 }
 
 // UpdateEventAnswer implements EventRepository.

--- a/usecase/event.go
+++ b/usecase/event.go
@@ -162,7 +162,7 @@ func (eu *eventUsecase) CreateUserAnswer(ctx context.Context, eventId ulid.ULID,
 		// ユーザーの回答数を数える
 		userAnswerCount, err := eu.er.FetchUserAnswerCount(ctx, tx, eventId)
 		if userAnswerCount != event.NumberOfParticipants {
-			util.SendMail(event.ID, event.ConfirmationEmail)
+			util.SendMail(event.ConfirmationEmail, "マジスケ", "イベント参加者が集まりました")
 			if err != nil {
 				return entity.UserEventAnswer{}, apperror.NewUnknownError(fmt.Errorf("failed to send confirmation email: %w", err), nil)
 			}

--- a/usecase/event.go
+++ b/usecase/event.go
@@ -156,6 +156,12 @@ func (eu *eventUsecase) CreateUserAnswer(ctx context.Context, eventId ulid.ULID,
 	}
 	newAnswer.Units = ansUnits
 
+	// ユーザーの回答数を数える
+	userAnswerCount, err := eu.er.FetchUserAnswerCount(ctx, tx, eventId)
+	if userAnswerCount != 0 {
+		return entity.UserEventAnswer{}, err
+	}
+
 	// commit!
 	err = tx.Commit()
 	if err != nil {


### PR DESCRIPTION
## 変更の概要

#12 

## なぜこの変更をするのか

参加者全員が回答したら代表者に通知を送るため

## やったこと

### entity/event.go

Event,EventRequest構造体の拡張

### controller/event.go

CreateAnswer関数にSendMail関数へ行く処理の追加

### usecase/event.go

CreateUserAnswer関数にユーザーの回答数を数えるFetchUserAnswerCount関数へ行く処理の追加

### repository/event.go

FetchUserAnswerCount関数の追加

## 課題

ブランチが違うことによるcontroller/event.goの「SendMail関数がありません」エラー

